### PR TITLE
Implement Firebase history storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Necesario para acceder a Firebase y otras operaciones de red -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/ai_life/domain/model/ConsultaGuardada.kt
+++ b/app/src/main/java/com/example/ai_life/domain/model/ConsultaGuardada.kt
@@ -1,0 +1,13 @@
+package com.example.ai_life.domain.model
+
+import com.google.firebase.database.IgnoreExtraProperties
+
+@IgnoreExtraProperties
+data class ConsultaGuardada(
+    var code: String = "",
+    val bpm: Int = 0,
+    val spo2: Int = 0,
+    val temperatura: Double = 0.0,
+    val diagnostico: String = "",
+    val fecha: Long = 0L
+)

--- a/app/src/main/java/com/example/ai_life/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/ai_life/presentation/navigation/NavGraph.kt
@@ -23,21 +23,25 @@ fun NavGraph() {
         composable("login_register"){ loginScreen(navController) }
         composable("dashboard"){dashboardScreen(navController)}
         composable(
-            route = "diagnostico/{code}/{bpm}/{spo2}/{temp}",
+            route = "diagnostico/{code}/{bpm}/{spo2}/{temp}/{diag}",
             arguments = listOf(
                 navArgument("code") { type = NavType.StringType },
                 navArgument("bpm") { type = NavType.IntType },
                 navArgument("spo2") { type = NavType.IntType },
-                navArgument("temp") { type = NavType.FloatType }
+                navArgument("temp") { type = NavType.FloatType },
+                navArgument("diag") { type = NavType.StringType }
             )
         ) { backStackEntry ->
             val code = backStackEntry.arguments?.getString("code") ?: ""
             val bpm = backStackEntry.arguments?.getInt("bpm") ?: 0
             val spo2 = backStackEntry.arguments?.getInt("spo2") ?: 0
             val temp = backStackEntry.arguments?.getFloat("temp") ?: 0f
+            val diagArg = backStackEntry.arguments?.getString("diag") ?: ""
+            val diag = java.net.URLDecoder.decode(diagArg, "UTF-8")
             DiagnosticoScreen(
                 navController,
-                Consulta(code, bpm, spo2, temp.toDouble())
+                Consulta(code, bpm, spo2, temp.toDouble()),
+                diag.ifBlank { null }
             )
         }
         composable("consulta"){ConsultaScreen(navController)}

--- a/app/src/main/java/com/example/ai_life/presentation/screens/Consulta.kt
+++ b/app/src/main/java/com/example/ai_life/presentation/screens/Consulta.kt
@@ -38,8 +38,10 @@ import androidx.navigation.compose.rememberNavController
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.IconButton
 import androidx.lifecycle.viewmodel.compose.viewModel
+import java.text.SimpleDateFormat
+import java.util.Date
 import com.example.ai_life.R
-import com.example.ai_life.domain.model.Consulta
+import com.example.ai_life.domain.model.ConsultaGuardada
 import com.example.ai_life.presentation.screens.viewmodel.ConsultaViewModel
 import kotlin.math.absoluteValue
 
@@ -111,7 +113,7 @@ fun ConsultaScreen(
 }
 
 @Composable
-fun ConsultaItem(navController: NavHostController, consulta: Consulta) {
+fun ConsultaItem(navController: NavHostController, consulta: ConsultaGuardada) {
     Column {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -119,6 +121,10 @@ fun ConsultaItem(navController: NavHostController, consulta: Consulta) {
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(text = "Código: ${consulta.code}", fontSize = 16.sp)
+                if (consulta.fecha > 0) {
+                    val date = SimpleDateFormat("dd/MM/yyyy").format(Date(consulta.fecha))
+                    Text(text = "Fecha: $date", fontSize = 16.sp)
+                }
                 Text(text = "BPM: ${consulta.bpm}", fontSize = 16.sp)
                 Text(text = "SpO2: ${consulta.spo2}", fontSize = 16.sp)
                 Text(text = "Temp: ${consulta.temperatura}", fontSize = 16.sp)
@@ -131,8 +137,9 @@ fun ConsultaItem(navController: NavHostController, consulta: Consulta) {
                     val tempFloat = consulta.temperatura.toFloat().absoluteValue
                         .let { "%.2f".format(it).toFloat() }
 
+                    val diag = java.net.URLEncoder.encode(consulta.diagnostico, "UTF-8")
                     navController.navigate(
-                        "diagnostico/${consulta.code}/${consulta.bpm}/${consulta.spo2}/$tempFloat"
+                        "diagnostico/${consulta.code}/${consulta.bpm}/${consulta.spo2}/$tempFloat/$diag"
                     )
                 },                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF040A7E)),
                 shape = RoundedCornerShape(50),

--- a/app/src/main/java/com/example/ai_life/presentation/screens/Diagnostico.kt
+++ b/app/src/main/java/com/example/ai_life/presentation/screens/Diagnostico.kt
@@ -38,6 +38,7 @@ import com.example.ai_life.presentation.screens.viewmodel.DiagnosticoViewModel
 fun DiagnosticoScreen(
     navController: NavHostController,
     consulta: Consulta,
+    diagnosticoGuardado: String? = null,
     viewModel: DiagnosticoViewModel = viewModel()
 ) {
     val context = LocalContext.current
@@ -46,7 +47,11 @@ fun DiagnosticoScreen(
     val status by viewModel.status.collectAsState()
 
     LaunchedEffect(Unit) {
-        viewModel.ejecutarDiagnostico(context, consulta)
+        if (diagnosticoGuardado == null) {
+            viewModel.ejecutarDiagnostico(context, consulta)
+        } else {
+            viewModel.setDiagnosticoGuardado(diagnosticoGuardado)
+        }
     }
 
     Scaffold(
@@ -142,6 +147,7 @@ fun PreviewDiagnostico() {
     val navController = rememberNavController()
     DiagnosticoScreen(
         navController,
-        Consulta(code = "123", bpm = 80, spo2 = 95, temperatura = 36.5)
+        Consulta(code = "123", bpm = 80, spo2 = 95, temperatura = 36.5),
+        "Normal"
     )
 }

--- a/app/src/main/java/com/example/ai_life/presentation/screens/viewmodel/DiagnosticoViewModel.kt
+++ b/app/src/main/java/com/example/ai_life/presentation/screens/viewmodel/DiagnosticoViewModel.kt
@@ -10,6 +10,9 @@ import com.example.ai_life.data.ml.ModelDownloaderUtil
 import com.example.ai_life.data.user.FirebaseUserRepository
 import com.example.ai_life.domain.model.Consulta
 import com.example.ai_life.domain.model.User
+import com.example.ai_life.domain.model.ConsultaGuardada
+import com.google.firebase.database.ktx.database
+import kotlinx.coroutines.tasks.await
 import com.example.ai_life.presentation.util.Constants
 import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,6 +40,8 @@ class DiagnosticoViewModel(
 
     // Guardamos el interpreter para reutilizarlo
     private var interpreter: Interpreter? = null
+
+    private val db = Firebase.database.reference
 
     fun ejecutarDiagnostico(context: Context, consulta: Consulta) {
         viewModelScope.launch {
@@ -86,7 +91,10 @@ class DiagnosticoViewModel(
                 _diagnosticoEtiqueta.value = etiqueta
                 Log.d(TAG, "Etiqueta mapeada: $etiqueta")
 
-                // 5) Resultado final
+                // 5) Guardar en historial y eliminar código
+                guardarHistorial(uid, consulta, etiqueta)
+
+                // Resultado final
                 _status.value = "Diagnóstico: $etiqueta"
                 Log.d(TAG, "Diagnóstico completado: $etiqueta")
 
@@ -109,5 +117,30 @@ class DiagnosticoViewModel(
             Log.e(TAG, "Error calculando edad", e)
             0
         }
+    }
+
+    private suspend fun guardarHistorial(uid: String, consulta: Consulta, diag: String) {
+        try {
+            val saved = ConsultaGuardada(
+                code = consulta.code,
+                bpm = consulta.bpm,
+                spo2 = consulta.spo2,
+                temperatura = consulta.temperatura,
+                diagnostico = diag,
+                fecha = System.currentTimeMillis()
+            )
+            db.child("users").child(uid).child("consultas").child(consulta.code)
+                .setValue(saved).await()
+
+            // eliminar del root para que no se pueda volver a consultar
+            db.child(consulta.code).removeValue().await()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error guardando historial", e)
+        }
+    }
+
+    fun setDiagnosticoGuardado(diag: String) {
+        Log.d(TAG, "Usando diagnóstico guardado: $diag")
+        _diagnosticoEtiqueta.value = diag
     }
 }

--- a/app/src/main/java/com/example/ai_life/presentation/screens/viewmodel/ViewModel.kt
+++ b/app/src/main/java/com/example/ai_life/presentation/screens/viewmodel/ViewModel.kt
@@ -3,13 +3,21 @@ package com.example.ai_life.presentation.screens.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.ai_life.domain.model.Consulta
+import com.example.ai_life.domain.model.ConsultaGuardada
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.tasks.await
 import com.google.firebase.database.ktx.database
+import android.util.Log
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class ConsultaViewModel : ViewModel() {
+
+    companion object {
+        private const val TAG = "ConsultaVM"
+    }
 
     // ⚠️ Si tus números están directamente bajo el root de la RTDB,
     //    usa Firebase.database.reference.
@@ -19,11 +27,15 @@ class ConsultaViewModel : ViewModel() {
     private val _code = MutableStateFlow("")
     val code: StateFlow<String> = _code
 
-    private val _consultas = MutableStateFlow<List<Consulta>>(emptyList())
-    val consultas: StateFlow<List<Consulta>> = _consultas
+    private val _consultas = MutableStateFlow<List<ConsultaGuardada>>(emptyList())
+    val consultas: StateFlow<List<ConsultaGuardada>> = _consultas
 
     private val _status = MutableStateFlow<String?>(null)
     val status: StateFlow<String?> = _status
+
+    init {
+        loadHistorial()
+    }
 
     fun onCodeChange(new: String) {
         _code.value = new
@@ -31,6 +43,7 @@ class ConsultaViewModel : ViewModel() {
 
     fun searchConsulta() {
         val lookup = code.value.trim()
+        Log.d(TAG, "Buscando codigo: '$lookup'")
         if (lookup.isEmpty()) {
             _status.value = "Ingresa un código"
             _consultas.value = emptyList()
@@ -43,27 +56,49 @@ class ConsultaViewModel : ViewModel() {
         db.child(lookup).get()
             .addOnSuccessListener { snap ->
                 if (snap.exists()) {
+                    Log.d(TAG, "Codigo $lookup encontrado en RTDB")
                     val bpm = snap.child("bpm").getValue(Int::class.java)
                     val spo2 = snap.child("spo2").getValue(Int::class.java)
                     val temp = snap.child("temperatura").getValue(Double::class.java)
                     if (bpm != null && spo2 != null && temp != null) {
-                        val consulta = Consulta(
+                        val consulta = ConsultaGuardada(
                             code = lookup,
                             bpm = bpm,
                             spo2 = spo2,
-                            temperatura = temp
+                            temperatura = temp,
+                            diagnostico = "",
+                            fecha = 0L
                         )
                         _consultas.value = listOf(consulta)
                         _status.value = "Consulta encontrada"
+                        Log.d(TAG, "Datos de consulta cargados: $consulta")
                     } else {
                         _status.value = "Datos incompletos para el código $lookup"
+                        Log.w(TAG, "Datos incompletos para $lookup")
                     }
                 } else {
                     _status.value = "No se encontró el código $lookup"
+                    Log.d(TAG, "Codigo $lookup no existe")
                 }
             }
             .addOnFailureListener { e ->
                 _status.value = "Error al buscar: ${e.message}"
+                Log.e(TAG, "Error buscando codigo", e)
             }
+    }
+
+    private fun loadHistorial() {
+        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
+        Log.d(TAG, "Cargando historial para UID=$uid")
+        viewModelScope.launch {
+            try {
+                val snapshot = db.child("users").child(uid).child("consultas").get().await()
+                val list = snapshot.children.mapNotNull { it.getValue(ConsultaGuardada::class.java) }
+                _consultas.value = list
+                Log.d(TAG, "Historial cargado: ${list.size} registros")
+            } catch (e: Exception) {
+                Log.e(TAG, "Error cargando historial", e)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- keep a record of past consultations in `ConsultaGuardada`
- store diagnosis result in Firebase and delete used code
- load user's consultation history in `ConsultaViewModel`
- show diagnosis list with date and forward label to `DiagnosticoScreen`
- allow `DiagnosticoScreen` to display stored diagnoses without rerunning inference
- add explicit INTERNET permission and add verbose logging for troubleshooting

## Testing
- `./gradlew assembleDebug` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_686f4a0ab4088327afe6da889fdd740d